### PR TITLE
Workaround to clear function return

### DIFF
--- a/tools/init.ps1
+++ b/tools/init.ps1
@@ -27,4 +27,6 @@ function global:Update-SolutionScripts()
 	}
 }
 
-Update-SolutionScripts
+# $null is workaround for NuGet echoing function output to command prompt
+# http://nuget.codeplex.com/workitem/1068
+Update-SolutionScripts > $null


### PR DESCRIPTION
Workaround for regression of http://nuget.codeplex.com/workitem/1068 in NuGet Package Manager Console. Send function output to null so it doesn't get picked up.
